### PR TITLE
แก้ไขภาษาไทยสำหรับอณาจักรขอมเล็กน้อย

### DIFF
--- a/Base/modules/age-antiquity/l10n/th_TH_Text.xml
+++ b/Base/modules/age-antiquity/l10n/th_TH_Text.xml
@@ -1280,7 +1280,7 @@
 			<Text>+30% [icon:YIELD_PRODUCTION] กำลังผลิต จากการเป็นสิ่งมหัศจรรย์ที่เกี่ยวข้องกับฮั่น</Text>		<!-- +30% [icon:YIELD_PRODUCTION] Production from being Han's associated Wonder. -->
 		</Replace>
 		<Replace Tag="LOC_TRAIT_KHMER_ABILITY_NAME" Language="th_TH">
-			<Text>เขกาม จัมนน</Text>		<!-- Ksekam Chamnon -->
+			<Text>ความอุดมสมบูรณ์ทางเกษตรกรรม</Text>		<!-- Ksekam Chamnon -->
 		</Replace>
 		<Replace Tag="LOC_CIVILIZATION_KHMER_DESCRIPTION" Language="th_TH">
 			<Text>เขตพื้นที่ที่อยู่ตามแม่น้ำ ไม่ทำให้ผลผลิตตามธรรมชาติ ของช่องลดลง</Text>		<!-- Districts on Rivers do not remove the natural yield of the tile. -->
@@ -2825,7 +2825,7 @@
 			<Text>ทุกครั้งที่คุณวิจัย เทคโนโลยี นี้, ถิ่นฐานนี้จะได้รับ[icon:YIELD_PRODUCTION] กำลังผลิต เท่ากับ 15% ของต้นทุนของมัน</Text>		<!-- Every time you research a Technology, this Settlement gains[icon:YIELD_PRODUCTION] Production equal to 15% of its cost. -->
 		</Replace>
 		<Replace Tag="LOC_WONDER_ANGKOR_WAT_NAME" Language="th_TH">
-			<Text>อังกอร์ วัด</Text>		<!-- Angkor Wat -->
+			<Text>นครวัด</Text>		<!-- Angkor Wat -->
 		</Replace>
 		<Replace Tag="LOC_WONDER_ANGKOR_WAT_DESCRIPTION" Language="th_TH">
 			<Text>+3[icon:YIELD_HAPPINESS] ความสุข, +1 ขีดจำกัดผู้เชี่ยวชาญในถิ่นฐานนี้, คงอยู่ตลอดกาล, จะต้องอยู่ติดกับแม่น้ำ</Text>		<!-- +3[icon:YIELD_HAPPINESS] Happiness. +1 Specialist Limit in this Settlement. Ageless. Must be placed adjacent to a River. -->
@@ -3294,16 +3294,16 @@
 			<Text>แนวคิดขอม</Text>		<!-- Khmer Civics -->
 		</Replace>
 		<Replace Tag="LOC_CIVIC_MOUSONG_NAME" Language="th_TH">
-			<Text>มูโซง</Text>		<!-- Mousong -->
+			<Text>มรสุม</Text>		<!-- Mousong -->
 		</Replace>
 		<Replace Tag="LOC_CIVIC_MOUSONG_QUOTE" Language="th_TH">
 			<Text>"ใครที่อยู่เบื้องบนควบคุมโลกนี้ เขารู้แท้จริงหรืออาจไม่รู้ก็ได้"</Text>		<!-- "Whose eye controls this world in highest heaven, he verily knows it, or perhaps he knows not." -->
 		</Replace>
 		<Replace Tag="LOC_CIVIC_MOUSONG_QUOTE_AUTHOR" Language="th_TH">
-			<Text>ริกเวท</Text>		<!-- The Rig Veda -->
+			<Text>ฤคเวท</Text>		<!-- The Rig Veda -->
 		</Replace>
 		<Replace Tag="LOC_CIVIC_AMNACH_NAME" Language="th_TH">
-			<Text>อัมนาช</Text>		<!-- Amnach -->
+			<Text>อำนาจ</Text>		<!-- Amnach -->
 		</Replace>
 		<Replace Tag="LOC_CIVIC_AMNACH_QUOTE" Language="th_TH">
 			<Text>"ไฟของกษัตริย์เหมือนกับดวงจันทร์ และศัตรูของเขาคล้อยลงสู่พื้นเหมือนดอกบัวในยามค่ำคืน"</Text>		<!-- "The king's fire was like the moon, and his enemies drooped to the ground like lotuses at night." -->


### PR DESCRIPTION
จากการค้นเพิ่มเติม คนไทยน่าจะคุ้นเคยกับคำพวกนี้มากกว่าครับ

> Amnach (ឣមនាច) is the Khmer word for “Authority” or the divine power behind said authority. While Chamnoun (ចមនយន), refers to “amount” or “abundance”, still trying to see the others.

- [อำนาจ](https://forums.civfanatics.com/threads/khmer-antiquity-age-civilization-discussion.692335/post-16685217)

> Ksekam, or as how I pronounced it, Ka-Se-Kam, (កសិកម្ម), means agriculture. I combined together with Chamnoun, (ចមនយន), you’d get something like Agricultural Abundance or Harvest of Plenty

- [ความอุดมสมบรูณ์ทางเกษตรกรรม](https://forums.civfanatics.com/threads/khmer-antiquity-age-civilization-discussion.692335/post-16685292)

> I’ve never heard of Mousong as itself, mostly we say “Kyalmosoung” (ខ្យល់មូសុង), which just means Monsoon Winds

- [Mousong](https://forums.civfanatics.com/threads/khmer-antiquity-age-civilization-discussion.692335/post-16685276) 
- [Monsoon -- มรสุม](https://th.wikipedia.org/wiki/มรสุม)

- [Rigveda -- ฤคเวท](https://th.wikipedia.org/wiki/ฤคเวท)
- [Angkor Wat -- นครวัด](https://th.wikipedia.org/wiki/นครวัด )
